### PR TITLE
Add pip requirements file and change build instructions to use a Python venv file for more reproducible builds.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 build/
+venv/

--- a/README.md
+++ b/README.md
@@ -4,24 +4,50 @@ This repo contains the source for YScope's docs hub at [docs.yscope.com].
 
 # Building
 
-To build the docs site, you need to install:
+The best way to build the docs site reproducibly is using a Python virtual
+environment.
 
-* [Sphinx] - a documentation generator that turns docs written in plain text
-  into a beautifully rendered form (e.g., a website). 
-* [MyST] - a plugin to allow writing docs using Markdown rather than
-  reStructuredText.
-* [sphinx_design] - A Sphinx plugin for responsive web components.
+## Requirements
 
+* GNU Make
+* Python3 (if it's not already installed)
+* [pip]
+* [virtualenv]
 
-Then run:
+## Setup
+
+* Create and enter a Python virtual environment:
+  ```shell
+  python3 -m venv venv
+  source ./venv/bin/activate
+  ```
+* Install the requirements:
+  ```shell
+  pip3 install -r requirements.txt
+  ```
+
+## Build
+
+* Enter the virtual environment (if you're not already inside):
+
+  ```
+  source ./venv/bin/activate
+  ```
+* Build the site:
+  ```shell
+  make html
+  ```
+
+The output will be in the `build` directory.
+
+# Teardown
+
+To quit the virtual environment, run:
 
 ```shell
-make html
+deactivate
 ```
 
-The output will be in the `build` folder.
-
 [docs.yscope.com]: https://docs.yscope.com
-[MyST]: https://myst-parser.readthedocs.io/en/latest/intro.html
-[Sphinx]: https://www.sphinx-doc.org/en/master/usage/installation.html
-[sphinx_design]: https://github.com/executablebooks/sphinx-design
+[pip]: https://pip.pypa.io/en/stable/installation/
+[virtualenv]: https://packaging.python.org/en/latest/guides/installing-using-pip-and-virtual-environments/#installing-virtualenv

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+furo==2022.12.7
+myst-parser==1.0.0
+sphinx==5.3.0
+sphinx-design==0.3.0


### PR DESCRIPTION
<!-- # References -->
<!-- Any issues or pull requests relevant to this pull request -->


# Description
<!-- Describe what this request will change/fix and provide any details 
necessary for reviewers -->

The previous build instructions relied platform-specific packages which could cause issues when the available package on the platform didn't agree with the packages installed via pip.

Using a Python virtual environment with a pip requirements file eliminates most of these concerns.