### PR TITLE
Taskfile: Add task `serve` for viewing output.

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,11 +31,11 @@ Follow the steps below to build and view the site locally.
 
 ## Viewing the output
 
-  Run task `serve` to install [http-server] and view the output:
+Run task `serve` to install [http-server] and view the output:
 
-  ```shell
-  task serve
-  ```
+```shell
+task serve
+```
 
 [docs.yscope.com]: https://docs.yscope.com
 [http-server]: https://www.npmjs.com/package/http-server

--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@ Follow the steps below to build and view the site locally.
 
 * python3
 * python3-venv
+* [Node.js] >= 16 to be able to [view the output](#viewing-the-output)
 * [Task]
-* [Node.js] 16 or above - [Viewing the output](#viewing-the-output)
 
 ## Building
 
@@ -31,12 +31,13 @@ Follow the steps below to build and view the site locally.
 
 ## Viewing the output
 
-Run task `serve` to install [http-server] and view the output:
-   ```shell
-   task serve
-   ```
+  Run task `serve` to install [http-server] and view the output:
+
+  ```shell
+  task serve
+  ```
 
 [docs.yscope.com]: https://docs.yscope.com
-[Task]: https://taskfile.dev/
-[Node.js]: https://nodejs.org/en/download/current
 [http-server]: https://www.npmjs.com/package/http-server
+[Node.js]: https://nodejs.org/en/download/current
+[Task]: https://taskfile.dev/

--- a/README.md
+++ b/README.md
@@ -8,9 +8,9 @@ Follow the steps below to build and view the site locally.
 
 ## Requirements
 
+* [Node.js] >= 16 to be able to [view the output](#viewing-the-output)
 * python3
 * python3-venv
-* [Node.js] >= 16 to be able to [view the output](#viewing-the-output)
 * [Task]
 
 ## Building

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Follow the steps below to build and view the site locally.
 * python3
 * python3-venv
 * [Task]
+* [Node.js] 16 or above - [Viewing the output](#viewing-the-output)
 
 ## Building
 
@@ -30,13 +31,12 @@ Follow the steps below to build and view the site locally.
 
 ## Viewing the output
 
-You can use [npm] with [http-server] to view the output:
-
-```shell
-npx http-server build/html -c-1
-```
+Run task `serve` to install [http-server] and view the output:
+   ```shell
+   task serve
+   ```
 
 [docs.yscope.com]: https://docs.yscope.com
-[npm]: https://nodejs.org/en/download/current
-[http-server]: https://www.npmjs.com/package/http-server
 [Task]: https://taskfile.dev/
+[Node.js]: https://nodejs.org/en/download/current
+[http-server]: https://www.npmjs.com/package/http-server

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -3,9 +3,9 @@ version: "3"
 vars:
   # Paths
   BUILD_DIR: "{{.TASKFILE_DIR}}/build"
-  VENV_DIR: "{{.BUILD_DIR}}/venv"
-  NODE_DEPS_DIR: "{{.BUILD_DIR}}/node"
   DOCS_OUTPUT_DIR: "{{.BUILD_DIR}}/html"
+  NODE_DEPS_DIR: "{{.BUILD_DIR}}/node"
+  VENV_DIR: "{{.BUILD_DIR}}/venv"
 
   # Other variables
   CHECKSUM_TAR_BASE_ARGS: >-
@@ -46,6 +46,13 @@ tasks:
         <(cd '{{.OUTPUT_DIR}}' && tar cf - {{.CHECKSUM_TAR_BASE_ARGS}} . | md5sum)
         "{{.CHECKSUM_FILE}}"
 
+  serve:
+    deps:
+      - "http-server"
+      - "docs"
+    cmds:
+      - "npm --prefix '{{.NODE_DEPS_DIR}}' exec http-server '{{.DOCS_OUTPUT_DIR}}' -c-1"
+
   venv:
     internal: true
     vars:
@@ -75,13 +82,6 @@ tasks:
         <(cd '{{.OUTPUT_DIR}}' && tar cf - {{.CHECKSUM_TAR_BASE_ARGS}} . | md5sum)
         "{{.CHECKSUM_FILE}}"
 
-  serve:
-    deps:
-      - "http-server"
-      - "docs"
-    cmds:
-      - "npm exec --prefix '{{.NODE_DEPS_DIR}}' http-server '{{.DOCS_OUTPUT_DIR}}' -c-1"
-
   http-server:
     internal: true
     vars:
@@ -89,11 +89,13 @@ tasks:
       OUTPUT_DIR: "{{.NODE_DEPS_DIR}}"
     cmds:
       - "rm -rf '{{.OUTPUT_DIR}}'"
-      - "npm install --prefix '{{.OUTPUT_DIR}}' http-server"
+      - "npm --prefix '{{.OUTPUT_DIR}}' install http-server"
       # Checksum the generated files (this command must be last)
       - |-
         cd "{{.OUTPUT_DIR}}"
         tar cf - {{.CHECKSUM_TAR_BASE_ARGS}} . | md5sum > "{{.CHECKSUM_FILE}}"
+    sources:
+      - "Taskfile.yml"
     status:
       - "test -f '{{.CHECKSUM_FILE}}'"
       - >-

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -4,6 +4,8 @@ vars:
   # Paths
   BUILD_DIR: "{{.TASKFILE_DIR}}/build"
   VENV_DIR: "{{.BUILD_DIR}}/venv"
+  NODE_DEPS_DIR: "{{.BUILD_DIR}}/node"
+  DOCS_OUTPUT_DIR: "{{.BUILD_DIR}}/html"
 
   # Other variables
   CHECKSUM_TAR_BASE_ARGS: >-
@@ -25,7 +27,7 @@ tasks:
     deps: ["venv"]
     vars:
       CHECKSUM_FILE: "{{.BUILD_DIR}}/{{.TASK}}.md5"
-      OUTPUT_DIR: "{{.BUILD_DIR}}/html"
+      OUTPUT_DIR: "{{.DOCS_OUTPUT_DIR}}"
     cmds:
       - |
         . "{{.VENV_DIR}}/bin/activate"
@@ -71,4 +73,30 @@ tasks:
       - >-
         diff
         <(cd '{{.OUTPUT_DIR}}' && tar cf - {{.CHECKSUM_TAR_BASE_ARGS}} . | md5sum)
+        "{{.CHECKSUM_FILE}}"
+
+  serve:
+    deps:
+      - "http-server"
+      - "docs"
+    cmds:
+      - "npm exec --prefix '{{.NODE_DEPS_DIR}}' http-server '{{.DOCS_OUTPUT_DIR}}' -c-1"
+
+  http-server:
+    internal: true
+    vars:
+      CHECKSUM_FILE: "{{.BUILD_DIR}}/{{.TASK}}.md5"
+      OUTPUT_DIR: "{{.NODE_DEPS_DIR}}"
+    cmds:
+      - "rm -rf '{{.OUTPUT_DIR}}'"
+      - "npm install --prefix '{{.OUTPUT_DIR}}' http-server"
+      # Checksum the generated files (this command must be last)
+      - |-
+        cd "{{.OUTPUT_DIR}}"
+        tar cf - {{.CHECKSUM_TAR_BASE_ARGS}} . | md5sum > "{{.CHECKSUM_FILE}}"
+    status:
+      - "test -f '{{.CHECKSUM_FILE}}'"
+      - >-
+        diff
+        <(cd '{{.NODE_DEPS_DIR}}' && tar cf - {{.CHECKSUM_TAR_BASE_ARGS}} . | md5sum)
         "{{.CHECKSUM_FILE}}"

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -48,8 +48,8 @@ tasks:
 
   serve:
     deps:
-      - "http-server"
       - "docs"
+      - "http-server"
     cmds:
       - "npm --prefix '{{.NODE_DEPS_DIR}}' exec http-server '{{.DOCS_OUTPUT_DIR}}' -c-1"
 


### PR DESCRIPTION
# References
PR #3 added instructions for viewing the generated `docs` output.

# Description
This PR adds a task `serve` in the Taskfile to automatically install `http-server` and serve the output with it.

# Validation
* Validated `task serve` installs `http-server` and its dependencies inside `<PROJECT_ROOT>/build/node/node_modules`, and the docs are served on all interfaces including http://127.0.0.1:8080 (no rebuild if everything is up to date).
* Validated changing any file under `build/node` and then running `task serve` triggers a rebuild on `http-server`.