### PR TITLE
Add clp project.

### DIFF
--- a/conf/projects.json
+++ b/conf/projects.json
@@ -1,5 +1,12 @@
 [
   {
+    "name": "clp",
+    "repo_url": "https://github.com/y-scope/clp.git",
+    "versions": [
+      "main"
+    ]
+  },
+  {
     "name": "clp-ffi-py",
     "repo_url": "https://github.com/y-scope/clp-ffi-py.git",
     "versions": [

--- a/docs/index.md
+++ b/docs/index.md
@@ -15,7 +15,7 @@ or, if no docs exist yet, it links to the project's repo.
 :gutter: 2
 
 :::{grid-item-card}
-:link: https://github.com/y-scope/clp
+:link: clp/main
 CLP (clp)
 ^^^
 A tool that can compress both text and JSON logs with higher compression than general-purpose


### PR DESCRIPTION
# Description
<!-- Describe what this request will change/fix and provide any details 
necessary for reviewers -->

> [!WARNING]
> Do not merge until y-scope/clp#370 has been merged.

y-scope/clp#370 adds a Sphinx docs site for clp. This PR adds the clp project to yscope-docs so that it can be rendered at https://docs.yscope.com

# Validation performed

* Followed the [deployment instructions](https://docs.yscope.com/dev-guide/misc-deploying.html#step-by-step-guide)
* Ran `task docs:serve` and validated that the clp's docs site was viewable from the main yscope-docs site.
