### PR TITLE
Try to append '.html' to any request for a non-existent file without an extension.

### DIFF
--- a/server/src/routes.js
+++ b/server/src/routes.js
@@ -5,6 +5,17 @@ import path from "node:path";
 
 
 /**
+ * Base set of options to be used when registering the fastify static plugin.
+ *
+ * @type {Readonly<{[key: string]: any}>}
+ */
+const FASTIFY_STATIC_BASE_OPTIONS = Object.freeze({
+    decorateReply: false,
+    extensions: ["html"],
+    redirect: true,
+});
+
+/**
  * Fastify plugin to register routes for the main docs site and each project docs site.
  * @param {import("fastify").FastifyInstance} fastify
  * @param {object} options
@@ -16,9 +27,8 @@ import path from "node:path";
 const routes = async (fastify, options) => {
     // Add route for main site
     await fastify.register(fastifyStatic, {
-        decorateReply: false,
+        ...FASTIFY_STATIC_BASE_OPTIONS,
         prefix: "/",
-        redirect: true,
         root: path.resolve(options.publicDir, "html"),
     });
 
@@ -43,7 +53,7 @@ const routes = async (fastify, options) => {
     for (const project of projects) {
         for (const version of project.versions) {
             await fastify.register(fastifyStatic, {
-                decorateReply: false,
+                ...FASTIFY_STATIC_BASE_OPTIONS,
                 root: path.resolve(
                     options.publicDir,
                     `${project.name}-${version}`,
@@ -52,7 +62,6 @@ const routes = async (fastify, options) => {
                     "html"
                 ),
                 prefix: `/${project.name}/${version}`,
-                redirect: true,
             });
         }
     }


### PR DESCRIPTION
# Description
<!-- Describe what this request will change/fix and provide any details 
necessary for reviewers -->

The docs site for https://github.com/y-scope/clp links within itself using links without an extension. The fastify-static plugin in this repo is not configured to automatically append `.html` to those links. So when a user clicks a link within the clp docs site, they get a 404 error. This PR configures fastify-static to append `.html` to those links.

# Validation performed

* Followed the [deployment instructions](https://docs.yscope.com/dev-guide/misc-deploying.html#step-by-step-guide)
* Ran `task docs:serve` and validated that extension-less links within clp's docs site no longer return a 404.
