### PR TITLE
Add config file to support docs version switcher for clp.

### DIFF
--- a/docs/_static/clp-versions.json
+++ b/docs/_static/clp-versions.json
@@ -1,0 +1,7 @@
+[
+  {
+    "version": "main",
+    "url": "https://docs.yscope.com/clp/main/",
+    "preferred": true
+  }
+]

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "license": "Apache-2.0",
       "dependencies": {
+        "@fastify/cors": "^9.0.1",
         "@fastify/static": "^7.0.1",
         "dotenv": "^16.4.5",
         "fastify": "^4.26.2"
@@ -148,6 +149,15 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
+    },
+    "node_modules/@fastify/cors": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/@fastify/cors/-/cors-9.0.1.tgz",
+      "integrity": "sha512-YY9Ho3ovI+QHIL2hW+9X4XqQjXLjJqsU+sMV/xFsxZkE8p3GNnYVFpoOxF7SsP5ZL76gwvbo3V9L+FIekBGU4Q==",
+      "dependencies": {
+        "fastify-plugin": "^4.0.0",
+        "mnemonist": "0.39.6"
+      }
     },
     "node_modules/@fastify/error": {
       "version": "3.4.1",
@@ -3243,6 +3253,14 @@
         "node": ">=16 || 14 >=14.17"
       }
     },
+    "node_modules/mnemonist": {
+      "version": "0.39.6",
+      "resolved": "https://registry.npmjs.org/mnemonist/-/mnemonist-0.39.6.tgz",
+      "integrity": "sha512-A/0v5Z59y63US00cRSLiloEIw3t5G+MiKz4BhX21FI+YBJXBOGW0ohFxTxO08dsOYlzxo87T7vGfZKYp2bcAWA==",
+      "dependencies": {
+        "obliterator": "^2.0.1"
+      }
+    },
     "node_modules/ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
@@ -3388,6 +3406,11 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/obliterator": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/obliterator/-/obliterator-2.0.4.tgz",
+      "integrity": "sha512-lgHwxlxV1qIg1Eap7LgIeoBWIMFibOjbrYPIPJZcI1mmGAI2m3lNYpK12Y+GBdPQ0U1hRwSord7GIaawz962qQ=="
     },
     "node_modules/on-exit-leak-free": {
       "version": "2.1.2",

--- a/server/package.json
+++ b/server/package.json
@@ -18,6 +18,7 @@
   },
   "homepage": "https://github.com/y-scope/yscope-docs#readme",
   "dependencies": {
+    "@fastify/cors": "^9.0.1",
     "@fastify/static": "^7.0.1",
     "dotenv": "^16.4.5",
     "fastify": "^4.26.2"

--- a/server/src/main.js
+++ b/server/src/main.js
@@ -1,10 +1,11 @@
-import routes from "./routes.js";
-
-import "dotenv/config.js";
 import Fastify from "fastify";
 import path from "node:path";
 import process from "node:process";
 
+import fastifyCors from "@fastify/cors";
+import "dotenv/config.js";
+
+import routes from "./routes.js";
 
 // eslint-disable-next-line new-cap
 const fastify = Fastify({
@@ -13,6 +14,12 @@ const fastify = Fastify({
 
 const start = async () => {
     try {
+        // Allow CORs for http://localhost:<port>
+        await fastify.register(fastifyCors, {
+            origin: /^http:\/\/localhost:\d+$/,
+            methods: ["GET"],
+        });
+
         await fastify.register(routes, {
             publicDir: path.resolve(process.env.PUBLIC_DIR),
             projectsConfigFile: path.resolve(process.env.PROJECTS_CONFIG_FILE),


### PR DESCRIPTION
# Description
<!-- Describe what this request will change/fix and provide any details 
necessary for reviewers -->

The docs theme we're using (pydata-sphinx-theme) supports a [version-switcher](https://pydata-sphinx-theme.readthedocs.io/en/stable/user_guide/version-dropdown.html). To enable the switcher, we need the valid/published versions for a project to be stored in a statically-hosted file. Every version of that project's docs will refer to the statically-hosted file to know what versions to display in the switcher.

We considered storing each of these files in the main branch of each project's repo and referring to it using raw.githubusercontent.com. However, raw.githubusercontent.com has a 5 minute caching delay and there don't seem to be any guarantees about its availability.

Instead, we made the decision to statically host each such file in this repo.

This PR adds the file for the clp project.

For projects to access the file while hosted locally, this PR also allow-lists CORs requests from localhost.

# Validation performed

* Used the hosts file to temporarily remap docs.yscope.com to localhost.
* Ran `task serve` to serve this site.
* Checked out https://github.com/y-scope/clp/pull/381 which adds the version switcher for the clp project.
* Modified `html_theme_options.switcher.json_url` to use http rather than https.
* Ran `task docs:serve` in the clp project.
* Validated that clp's version switcher showed "main" and linked to the CLP project docs on docs.yscope.com.
