### PR TITLE
Implement `sed -i` manually to fix build on macOS.

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -127,10 +127,16 @@ tasks:
     cmds:
       - "rm -rf '{{.OUTPUT_DIR}}'"
       - "python3 -m venv '{{.OUTPUT_DIR}}'"
-      # Remove calls to `hash` since Task uses `gosh` rather than `bash`.
+      # Remove calls to `hash` from the venv activation script since Task uses `gosh` rather than
+      # `bash`.
       # NOTE: Older versions of Python's venv would only call `hash` if they detected the running
       # shell was one that had the command, but that's not the case in newer versions.
-      - "sed -i 's/^\\s*hash\\s\\+.*//g' '{{.OUTPUT_DIR}}/bin/activate'"
+      - |-
+        # NOTE: We can't use `sed -i` since `-i` has different syntax on Linux and macOS
+        src="{{.OUTPUT_DIR}}/bin/activate"
+        dst="{{.OUTPUT_DIR}}/bin/activate.tmp"
+        sed --regexp-extended 's/^([[:space:]]*)hash[[:space:]]+.*/\1true/g' "${src}" > "${dst}"
+        mv "${dst}" "${src}"
       - |-
         . "{{.OUTPUT_DIR}}/bin/activate"
         pip3 install --upgrade -r requirements.txt

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -132,10 +132,12 @@ tasks:
       # NOTE: Older versions of Python's venv would only call `hash` if they detected the running
       # shell was one that had the command, but that's not the case in newer versions.
       - |-
-        # NOTE: We can't use `sed -i` since `-i` has different syntax on Linux and macOS
+        # NOTE:
+        # 1. We can't use `sed -i` since `-i` has different syntax on Linux and macOS
+        # 2. We can't use `--regexp` instead of `-E` since `--regexp` is not supported on macOS
         src="{{.OUTPUT_DIR}}/bin/activate"
         dst="{{.OUTPUT_DIR}}/bin/activate.tmp"
-        sed --regexp-extended 's/^([[:space:]]*)hash[[:space:]]+.*/\1true/g' "${src}" > "${dst}"
+        sed -E 's/^([[:space:]]*)hash[[:space:]]+.*/\1true/g' "${src}" > "${dst}"
         mv "${dst}" "${src}"
       - |-
         . "{{.OUTPUT_DIR}}/bin/activate"


### PR DESCRIPTION
# Description
<!-- Describe what this request will change/fix and provide any details 
necessary for reviewers -->

We currently use `sed -i` to remove calls to `hash` in the Python venv activation script because `task` uses `gosh` and `gosh` doesn't have `hash`. Unfortunately, `sed -i` has different semantics on Linux and macOS; on macOS, we currently get this error:

```
sed: -I or -i may not be used with stdin
```

To resolve this, this PR replaces the call to `sed -i` with an equivalent sequence of commands.

# Validation performed

Validated `task docs serve` was able to build and serve the site.
