### PR TITLE
Add config to serve CLP v0.1.0.

### DIFF
--- a/conf/projects.json
+++ b/conf/projects.json
@@ -3,7 +3,7 @@
     "name": "clp",
     "repo_url": "https://github.com/y-scope/clp.git",
     "versions": [
-      "0.1.0",
+      "v0.1.0",
       "main"
     ]
   },

--- a/conf/projects.json
+++ b/conf/projects.json
@@ -3,6 +3,7 @@
     "name": "clp",
     "repo_url": "https://github.com/y-scope/clp.git",
     "versions": [
+      "0.1.0",
       "main"
     ]
   },

--- a/docs/_static/clp-versions.json
+++ b/docs/_static/clp-versions.json
@@ -1,5 +1,9 @@
 [
   {
+    "version": "0.1.0",
+    "url": "https://docs.yscope.com/clp/0.1.0/"
+  },
+  {
     "version": "main",
     "url": "https://docs.yscope.com/clp/main/",
     "preferred": true


### PR DESCRIPTION
# Description
<!-- Describe what this request will change/fix and provide any details 
necessary for reviewers -->

We are releasing [CLP v0.1.0](https://github.com/y-scope/clp/releases/tag/v0.1.0) soon, so this PR adds the necessary config to serve CLP v0.1.0's docs from docs.yscope.com.

Note that the version is officially called "0.1.0" but the tag in the CLP repo is "v0.1.0" based on convention.

# Validation performed

* Locally mapped docs.yscope.com to localhost
* Downloaded and checked out the projects
  ```shell
  task download-projects
  cd build/clp-v0.1.0
  # This is necessary due to a missing checkout step in scripts/download-projects.py
  git checkout v0.1.0
  cd ../../
  ```
* Modified `build/clp-{main,v0.1.0}/docs/conf/conf.py` to change `https://docs.yscope.com` to `http://docs.yscope.com:3000` (i.e., the locally served one).
* Built the project docs sites.
  ```shell
  cd build/clp-v0.1.0 && task docs:site
  cd ../clp-main && task docs:site
  cd ../clp-ffi-py-main && task docs:site
  cd ../../
  ```
* Served the docs and verified the CLP docs had both 0.1.0 and main as options in the version switcher.
  ```shell
  task serve
  ```
