### PR TITLE
Fix CLP v0.1.0 URL in version switcher config.

### DIFF
--- a/docs/_static/clp-versions.json
+++ b/docs/_static/clp-versions.json
@@ -1,7 +1,7 @@
 [
   {
     "version": "0.1.0",
-    "url": "https://docs.yscope.com/clp/0.1.0/"
+    "url": "https://docs.yscope.com/clp/v0.1.0/"
   },
   {
     "version": "main",


### PR DESCRIPTION
# Description
<!-- Describe what this request will change/fix and provide any details 
necessary for reviewers -->

#12 added the config to serve CLP v0.1.0's docs but mistakenly set the URL to "...clp/0.1.0" rather than "...clp/v0.1.0", where the latter matches the release's tag. This PR addresses the issue.

A future PR will automate generating the version switch config based on `conf/projects.json`, so this error will no longer be possible.