### PR TITLE
Add config to serve CLP v0.1.1.

### DIFF
--- a/conf/projects.json
+++ b/conf/projects.json
@@ -3,6 +3,7 @@
     "name": "clp",
     "repo_url": "https://github.com/y-scope/clp.git",
     "versions": [
+      "v0.1.1",
       "v0.1.0",
       "main"
     ]

--- a/docs/_static/clp-versions.json
+++ b/docs/_static/clp-versions.json
@@ -1,5 +1,9 @@
 [
   {
+    "version": "0.1.1",
+    "url": "https://docs.yscope.com/clp/v0.1.1/"
+  },
+  {
     "version": "0.1.0",
     "url": "https://docs.yscope.com/clp/v0.1.0/"
   },


### PR DESCRIPTION
# Description

We are releasing [CLP v0.1.1](https://github.com/y-scope/clp/releases/tag/v0.1.1) soon, so this PR adds the necessary config to serve CLP v0.1.1's docs from docs.yscope.com.

Note that the version is officially called "0.1.1" but the tag in the CLP repo is "v0.1.1" based on convention.

