### PR TITLE
Fix typo in Taskfile attribute name `platforms`.

### DIFF
--- a/docs/dev-guide/contrib-guides-taskfiles.md
+++ b/docs/dev-guide/contrib-guides-taskfiles.md
@@ -233,7 +233,7 @@ attributes.
   * `sources`
 * Environment control
   * `dir`
-  * `platform`
+  * `platforms`
   * `set`
   * `shopt`
 * Outputs


### PR DESCRIPTION
# References
The task attribute for specifying on which platforms a task should run should be `platforms` instead of `platform`: https://taskfile.dev/usage/#platform-specific-tasks-and-commands

# Description
1. Fix typo in Taskfile attribute name `platforms`.
