### PR TITLE
feat: Add yscope-log-viewer project (fixes #22).

### DIFF
--- a/conf/projects.json
+++ b/conf/projects.json
@@ -17,5 +17,12 @@
     "versions": [
       "main"
     ]
+  },
+  {
+    "name": "yscope-log-viewer",
+    "repo_url": "https://github.com/y-scope/yscope-log-viewer.git",
+    "versions": [
+      "main"
+    ]
   }
 ]

--- a/docs/index.md
+++ b/docs/index.md
@@ -95,7 +95,7 @@ deserializing, searching, and analyzing CLP IR files.
 :gutter: 2
 
 :::{grid-item-card}
-:link: https://github.com/y-scope/yscope-log-viewer
+:link: yscope-log-viewer/main
 YScope Log Viewer (yscope-log-viewer)
 ^^^
 A web interface for viewing logs that use CLP’s IR stream format including features like filtering


### PR DESCRIPTION
# Description
<!-- Describe what this request will change/fix and provide any details 
necessary for reviewers -->

y-scope/yscope-log-viewer#127 added a Sphinx docs site for yscope-log-viewer. This PR adds the project to yscope-docs so that it can be rendered at https://docs.yscope.com

# Validation performed

* Followed the [deployment instructions](https://docs.yscope.com/dev-guide/misc-deploying.html#step-by-step-guide)
* Ran `task serve` and validated that the yscope-log-viewer's docs site was viewable from the main yscope-docs site.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a new project, "yscope-log-viewer," to the project configuration.
  
- **Documentation**
  - Updated the link for the "YScope Log Viewer" in the documentation to a relative path for improved navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->