### PR TITLE
feat(download-projects): Perform shallow clone of each project, and checkout each project's submodules concurrently.

### DIFF
--- a/scripts/download-projects.py
+++ b/scripts/download-projects.py
@@ -1,7 +1,7 @@
 import argparse
 import json
 import logging
-import multiprocessing
+import os
 import subprocess
 from pathlib import Path
 import sys
@@ -38,6 +38,9 @@ def _clone_repo_at_ref(repo_url: str, ref_name: str, output_dir: Path):
     :param output_dir:
     :return: Whether the clone was successful
     """
+    cpu_count = os.cpu_count()
+    if cpu_count is None:
+        cpu_count = 1
     cmd = [
         "git",
         "clone",
@@ -45,7 +48,7 @@ def _clone_repo_at_ref(repo_url: str, ref_name: str, output_dir: Path):
         "--branch", ref_name,
         "--recurse-submodules",
         "--shallow-submodules",
-        "--jobs", str(multiprocessing.cpu_count()),
+        "--jobs", str(cpu_count),
         repo_url,
         str(output_dir),
     ]


### PR DESCRIPTION
# Description
<!-- Describe what this request will change/fix and provide any details 
necessary for reviewers -->

`scripts/download-projects.py` currently only checks out each project's repository and then checks out the relevant version of that project, but this has a few issues:

1, Some projects require their submodules to be checked out in order to build the docs site.
2, It's inefficient to check out the entire history of a project when we only need a single version for each docs site.

To address (2), this PR updates the script to perform a shallow clone of the repository directly at the relevant version. To address (1), this PR updates the script to checkout each project's submodules (concurrently, for performance).

# Validation performed

* Followed the first three steps of the [deployment guide](https://docs.yscope.com/dev-guide/misc-deploying.html#step-by-step-guide).
* `task serve`
* Validated the following project docs sites were served:
  * clp
    * version: main
    * version: 0.2.1 (checked by manually changing the URL; using the version switcher will instead load the version from docs.yscope.com)
  * clp-ffi-py:main
  * yscope-log-viewer:main


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced project cloning capabilities with new options for depth, branches, and submodules.
	- Streamlined process for cloning and checking out specific versions in a single operation.

- **Bug Fixes**
	- Improved error handling and logging for cloning operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->