### PR TITLE
feat: Add config to serve CLP v0.3.0.

### DIFF
--- a/conf/projects.json
+++ b/conf/projects.json
@@ -3,6 +3,7 @@
     "name": "clp",
     "repo_url": "https://github.com/y-scope/clp.git",
     "versions": [
+      "v0.3.0",
       "v0.2.1",
       "v0.2.0",
       "v0.1.3",

--- a/docs/_static/clp-versions.json
+++ b/docs/_static/clp-versions.json
@@ -1,5 +1,9 @@
 [
   {
+    "version": "0.3.0",
+    "url": "https://docs.yscope.com/clp/v0.3.0/"
+  },
+  {
     "version": "0.2.1",
     "url": "https://docs.yscope.com/clp/v0.2.1/"
   },


### PR DESCRIPTION
# Description

We are releasing [CLP v0.3.0](https://github.com/y-scope/clp/releases/tag/v0.3.0) soon, so this PR adds the necessary config to serve CLP v0.3.0's docs from docs.yscope.com.

Note that the version is officially called "0.3.0" but the tag in the CLP repo is "v0.3.0" based on convention.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated project version to v0.3.0
	- Added new documentation version entry for v0.3.0
	- Updated documentation version list with new URL for v0.3.0

<!-- end of auto-generated comment: release notes by coderabbit.ai -->