### PR TITLE
fix(dev-guide): Fix typo in Taskfile guidelines.

### DIFF
--- a/docs/dev-guide/contrib-guides-taskfiles.md
+++ b/docs/dev-guide/contrib-guides-taskfiles.md
@@ -48,7 +48,8 @@ my-task:
 
 The task attributes `sources` and `generates` are supposed to allow us to control whether a task is
 run based on whether its source files or generated files have changed, but `task`'s behaviour may
-seem intuitive. So to understand the guidelines, you'll first need to understand `task`'s behaviour.
+seem unintuitive. So to understand the guidelines, you'll first need to understand `task`'s
+behaviour.
 
 `task` has two methods to track changes to source files, specified using the `method` attribute:
 `checksum` which tracks changes to the source files checksums and `timestamp` which tracks changes


### PR DESCRIPTION
# Description

As title says.

# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

NA


[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Modified wording in the developer guide to improve clarity regarding the task system behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->