### PR TITLE
feat: Add config to serve CLP v0.5.1.

### DIFF
--- a/conf/projects.json
+++ b/conf/projects.json
@@ -3,6 +3,7 @@
     "name": "clp",
     "repo_url": "https://github.com/y-scope/clp.git",
     "versions": [
+      "v0.5.1",
       "v0.5.0",
       "v0.4.0",
       "v0.3.0",

--- a/docs/_static/clp-versions.json
+++ b/docs/_static/clp-versions.json
@@ -1,5 +1,9 @@
 [
   {
+    "version": "0.5.1",
+    "url": "https://docs.yscope.com/clp/v0.5.1/"
+  },
+  {
     "version": "0.5.0",
     "url": "https://docs.yscope.com/clp/v0.5.0/"
   },


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->

We are releasing [CLP v0.5.1](https://github.com/y-scope/clp/releases/tag/v0.5.1) soon, so this PR adds the necessary config to serve CLP v0.5.1's docs from docs.yscope.com.

Note that the version is officially called "0.5.1" but the tag in the CLP repo is "v0.5.1" based on convention.

# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->


<!-- Describe what tests and validation you performed on the change. -->

* Locally mapped docs.yscope.com to localhost
* Downloaded and checked out the projects
  ```shell
  task docs:download-projects
  ```
* Modified `build/clp-{main,v0.5.1}/docs/conf/conf.py` to change `https://docs.yscope.com` to `http://docs.yscope.com:3000` (i.e., the locally served one).
* Built the project docs sites.
  ```shell
  cd build/clp-v0.5.1 && task docs:site
  cd ../clp-main && task docs:site
  cd ../../
  ```
* Served the docs and verified the CLP docs had both 0.5.1 and main as options in the version switcher.
  ```shell
  task serve
  ```

[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Documentation
  - Added CLP docs entry for version 0.5.1 with link to the new documentation site.
  - Updated the versions list so 0.5.1 appears as the latest selectable version.

- Chores
  - Updated project configuration to include version v0.5.1 in the versions array.
  - Ensured no changes to existing version entries or structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->