### PR TITLE
fix(docs): Remove outdated `ROOT_TASKFILE` variable guideline from Taskfile contribution guide.

### DIFF
--- a/docs/dev-guide/contrib-guides-taskfiles.md
+++ b/docs/dev-guide/contrib-guides-taskfiles.md
@@ -60,10 +60,7 @@ my-task:
 
 ## Built-in variables
 
-1. Don't use the variable `{{.ROOT_TASKFILE}}`
-   * v3.35.1 has a bug that makes it equivalent to `ROOT_DIR` (i.e., the parent directory of the root
-     Taskfile, rather than the path to the root Taskfile).
-2. When using the variable `{{.TASK}}` in a task within a namespace (e.g., it's in a nested
+1. When using the variable `{{.TASK}}` in a task within a namespace (e.g., it's in a nested
    Taskfile), replace the `:` in the name with `#` as follows: `{{.TASK | replace \":\" \"#\"}}`.
    * This ensures the task name can be used as a filename.
 


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->

Remove the guideline about avoiding `{{.ROOT_TASKFILE}}` from the Taskfile contribution guide since we no longer use Task v3.35.

# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->

* Built and served the docs site.
  ```shell
  task docs:serve
  ```
  Output (abbreviated):
  ```
  task: [docs:http-server] npm --prefix '.../build/node-deps' install http-server
  ...
  task: [create-venv-docs] pip3 install --upgrade -r "requirements.txt"
  ...
  ```
* Verified the "Built-in variables" section renders correctly with only the `{{.TASK}}` guideline, numbered as item 1, and no trace of the removed `{{.ROOT_TASKFILE}}` bullet.
  ```shell
  curl -s http://127.0.0.1:8080/dev-guide/contrib-guides-taskfiles.html | grep -A 10 "Built-in variables"
  ```
  Output:
  ```html
  <h2>Built-in variables<a class="headerlink" href="#built-in-variables" title="Link to this heading">#</a></h2>
  <ol class="arabic simple">
  <li><p>When using the variable <code class="docutils literal notranslate"><span class="pre">{{.TASK}}</span></code> in a task within a namespace (e.g., it's in a nested
  Taskfile), replace the <code class="docutils literal notranslate"><span class="pre">:</span></code> in the name with <code class="docutils literal notranslate"><span class="pre">#</span></code> as follows: <code class="docutils literal notranslate"><span class="pre">{{.TASK</span> <span class="pre">|</span> <span class="pre">replace</span> <span class="pre">\&quot;:\&quot;</span> <span class="pre">\&quot;#\&quot;}}</span></code>.</p>
  <ul class="simple">
  <li><p>This ensures the task name can be used as a filename.</p></li>
  </ul>
  </li>
  </ol>
  ```


[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved clarity in contributor guides by removing outdated warnings and reorganizing built-in variables guidance for better readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->