### PR TITLE
feat(dev-docs): Require the measurement unit in names if it is not in the static type.

### DIFF
--- a/docs/dev-docs/dev-guide/contrib-guides-general.md
+++ b/docs/dev-docs/dev-guide/contrib-guides-general.md
@@ -4,9 +4,9 @@ Follow the guidelines below when writing and updating any source files.
 
 ## Naming
 
-### Units
+### Measurement units
 
-When handling data with units the unit must always be explicitly stated.
+When handling data with measurement units, the unit must always be explicitly stated.
 If the unit is not statically available in the type information then it must be added to the name,
 preferably as a suffix.
 

--- a/docs/dev-docs/dev-guide/contrib-guides-general.md
+++ b/docs/dev-docs/dev-guide/contrib-guides-general.md
@@ -2,6 +2,21 @@
 
 Follow the guidelines below when writing and updating any source files.
 
+## Naming
+
+### Units
+
+When handling data with units the unit must always be explicitly stated.
+If the unit is not statically available in the type information then it must be added to the name,
+preferably as a suffix.
+
+For example, in C++ when storing a measure of kilobytes inside an integer type name the variable
+with a `_kb` suffix (e.g. `encoded_size_kb`). Similarly, when measuring milliseconds in an integer
+add an `_ms` suffix (e.g. `parsing_time_ms`).
+
+An example when it is not necessary to add the unit to the name is when using `std::chrono` in C++
+as the typing (and API) explicitly handles the type.
+
 ## Code organization
 
 (declaration-order)=

--- a/docs/dev-docs/dev-guide/contrib-guides-general.md
+++ b/docs/dev-docs/dev-guide/contrib-guides-general.md
@@ -7,10 +7,10 @@ Follow the guidelines below when writing and updating any source files.
 ### Measurement units
 
 When handling data with measurement units, the unit must always be explicitly stated.
-If the unit is not statically available in the type information then it must be added to the name,
+If the unit is not statically available in the type information, then it must be added to the name,
 preferably as a suffix.
 
-For example, in C++ when storing a measure of kilobytes inside an integer type name the variable
+For example, in C++ when storing a measure of kilobytes inside an integer type, name the variable
 with a `_kb` suffix (e.g. `encoded_size_kb`). Similarly, when measuring milliseconds in an integer
 add an `_ms` suffix (e.g. `parsing_time_ms`).
 

--- a/docs/dev-docs/dev-guide/contrib-guides-general.md
+++ b/docs/dev-docs/dev-guide/contrib-guides-general.md
@@ -10,16 +10,20 @@ When handling data with measurement units, the unit must always be explicitly st
 If the unit is not statically available in the type information, then it must be added to the name,
 preferably as a suffix.
 
-For example, in C++ when storing a measure of kilobytes inside an integer type, name the variable
-with a `_kb` suffix (e.g. `encoded_size_kb`). Similarly, when measuring milliseconds in an integer
-add an `_ms` suffix (e.g. `parsing_time_ms`).
+For example, in C++ when storing a measure of kibibytes inside an integer type, name the variable
+with a `_kib` suffix (e.g. `encoded_size_kib`).
 
-An example when it is not necessary to add the unit to the name is when using `std::chrono` in C++
-as the typing (and API) explicitly handles the type.
+It is not a requirement to use abbreviations, as the goal is clarity. For example, when measuring
+milliseconds adding `_ms` is actually ambiguous as to whether it's milli or mega, so we use
+`_millisecs` (e.g. `parsing_time_millisecs`).
+
+Using `std::chrono` in C++ is an example of when the type (and API) explicitly handles the unit and
+it is unnecessary to add a suffix.
 
 ## Code organization
 
 (declaration-order)=
+
 ### Declaration order
 
 Organize declarations in order of:


### PR DESCRIPTION


<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->

Added a general section to explicitly name measurement units if not handled by the type.

# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->
CI passing.


[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new naming guidance section.
  * Clarified how to name variables and fields that represent measurement units.
  * Recommended including units in names when not already clear from type information (e.g., suffixes like `_kb` or `_millisecs`).
  * Noted an exception when the type or API already conveys unit details (such as strongly typed time APIs).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->